### PR TITLE
feat: add SenseNova support for vision and image generation

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,8 +2,9 @@
  * Bundled `vision-review` and `media-tools` skill provider.
  *
  * Ships two free, self-contained skills for DeepSeek Harness:
- * - `vision-review`: read / analyze images via Zhipu GLM-4V-Flash.
- * - `media-tools`: generate images via SiliconFlow Kolors.
+ * - `vision-review`: read / analyze images via Zhipu GLM-4V-Flash,
+ *   with optional SiliconFlow / SenseNova / Gemini fallbacks.
+ * - `media-tools`: generate images via SenseNova U1 Fast or SiliconFlow Kolors.
  *
  * The plugin registers a single provider on `ctx.skills`. Skill bodies live
  * under `skills/<name>/SKILL.md` and their scripts under `skills/<name>/scripts/`.
@@ -28,14 +29,14 @@ const SKILLS = [
   {
     name: 'vision-review',
     description:
-      '免费读图与视觉检查。当用户要分析、识别、检查或描述图片/截图，检查界面或布局的视觉问题（文字重叠、溢出、错位），检测水印/Logo，或把图片内容转成文字时使用。基于智谱 GLM-4V-Flash（免费）；key 取自环境变量或 ~/.dsh/secrets/media-tools.env，永不写进 skill。',
+      '免费读图与视觉检查。当用户要分析、识别、检查或描述图片/截图，检查界面或布局的视觉问题（文字重叠、溢出、错位），检测水印/Logo，或把图片内容转成文字时使用。基于智谱 GLM-4V-Flash（免费），可选 SenseNova / SiliconFlow / Gemini；key 取自环境变量或 ~/.dsh/secrets/media-tools.env，永不写进 skill。',
     body: new URL('./skills/vision-review/SKILL.md', import.meta.url),
     resourceDir: './skills/vision-review/',
   },
   {
     name: 'media-tools',
     description:
-      '免费生成图片。当用户要生成图片、插画、头像、背景、banner 等（包括付费图片额度不可用时）使用。基于 SiliconFlow Kolors（免费、无水印）；key 取自环境变量或 ~/.dsh/secrets/media-tools.env，永不写进 skill。',
+      '免费生成图片。当用户要生成图片、插画、头像、背景、banner 等（包括付费图片额度不可用时）使用。优先 SenseNova U1 Fast，其次 SiliconFlow Kolors；key 取自环境变量或 ~/.dsh/secrets/media-tools.env，永不写进 skill。',
     body: new URL('./skills/media-tools/SKILL.md', import.meta.url),
     resourceDir: './skills/media-tools/',
   },
@@ -72,15 +73,15 @@ const provider = {
 }
 
 /**
- * Seed for the `zhipu-vision` provider route written into the `llm-pi-ai`
- * settings namespace on a fresh install, so the model selector gains
- * 「智谱 GLM-4V-Flash（视觉）」 without hand-editing settings.yaml.
+ * Seeds for the `zhipu-vision` and `sensenova-vision` provider routes written
+ * into the `llm-pi-ai` settings namespace on a fresh install, so the model
+ * selector gains 「智谱 GLM-4V-Flash（视觉）」 and 「商汤 SenseNova（视觉）」
+ * without hand-editing settings.yaml.
  *
- * The seed is additive and idempotent: it only applies when no
- * `zhipu-vision` provider is configured, and it never touches other
- * providers or a user's existing customization. The GLM key itself is never
- * bundled — `apiKeyEnv: GLM_API_KEY` names a credential the user supplies
- * through DSH's credential store.
+ * The seed is additive and idempotent: it only applies when a provider is not
+ * configured, and it never touches other providers or a user's existing
+ * customization. API keys themselves are never bundled — `apiKeyEnv` names a
+ * credential the user supplies through DSH's credential store.
  */
 const ZHIPU_VISION_SEED = {
   apiKeyEnv: 'GLM_API_KEY',
@@ -99,11 +100,26 @@ const ZHIPU_VISION_SEED = {
   ],
 }
 
+const SENSENOVA_VISION_SEED = {
+  apiKeyEnv: 'SENSENOVA_API_KEY',
+  displayName: '商汤 SenseNova（视觉）',
+  api: 'openai-completions',
+  baseURL: 'https://token.sensenova.cn/v1',
+  models: [
+    {
+      id: 'sensenova-6.7-flash-lite',
+      input: ['text', 'image'],
+      contextWindow: 262144,
+      maxTokens: 65536,
+    },
+  ],
+}
+
 /**
- * Seed the `zhipu-vision` route when absent. Settings reads/writes are
- * best-effort: a composition without the settings service, a read-only
- * provider, or a not-yet-registered namespace all skip silently (and log a
- * warning) rather than failing the skill provider registration.
+ * Seed the `zhipu-vision` / `sensenova-vision` routes when absent. Settings
+ * reads/writes are best-effort: a composition without the settings service, a
+ * read-only provider, or a not-yet-registered namespace all skip silently
+ * (and log a warning) rather than failing the skill provider registration.
  */
 async function seedVisionModel(ctx) {
   const settings = ctx.get('settings')
@@ -114,10 +130,14 @@ async function seedVisionModel(ctx) {
       && section.providers !== null && typeof section.providers === 'object'
       ? section.providers
       : {}
-    if (providers['zhipu-vision'] !== undefined) return
-    // Deep merge: adds only the zhipu-vision key under `providers`, leaving
+    // Deep merge: adds only missing provider keys under `providers`, leaving
     // every other provider route exactly as the user configured it.
-    await settings.update('llm-pi-ai', { providers: { 'zhipu-vision': ZHIPU_VISION_SEED } })
+    const missing = {}
+    if (providers['zhipu-vision'] === undefined) missing['zhipu-vision'] = ZHIPU_VISION_SEED
+    if (providers['sensenova-vision'] === undefined) missing['sensenova-vision'] = SENSENOVA_VISION_SEED
+    if (Object.keys(missing).length > 0) {
+      await settings.update('llm-pi-ai', { providers: missing })
+    }
   } catch (error) {
     console.warn(
       `dsh-media-skills: vision model seeding skipped: ${error instanceof Error ? error.message : String(error)}`,

--- a/index.js
+++ b/index.js
@@ -104,10 +104,10 @@ const SENSENOVA_VISION_SEED = {
   apiKeyEnv: 'SENSENOVA_API_KEY',
   displayName: '商汤 SenseNova（视觉）',
   api: 'openai-completions',
-  baseURL: 'https://token.sensenova.cn/v1',
+  baseURL: 'https://token.sensenova.ai/v1',
   models: [
     {
-      id: 'sensenova-6.7-flash-lite',
+      id: 'sensenova-6.8-flash-lite',
       input: ['text', 'image'],
       contextWindow: 262144,
       maxTokens: 65536,

--- a/skills/media-tools/SKILL.md
+++ b/skills/media-tools/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: media-tools
-description: "免费生成图片。当用户要生成图片、插画、头像、背景、banner 等（包括付费图片额度不可用时）使用。基于 SiliconFlow Kolors（免费、无水印）；key 取自环境变量或 ~/.dsh/secrets/media-tools.env，永不写进 skill。"
+description: "免费生成图片。当用户要生成图片、插画、头像、背景、banner 等（包括付费图片额度不可用时）使用。优先 SenseNova U1 Fast，其次 SiliconFlow Kolors；key 取自环境变量或 ~/.dsh/secrets/media-tools.env，永不写进 skill。"
 ---
 
 # Media Tools（免费生图）
 
-免费生图，基于 SiliconFlow Kolors。Key 永不写进本 skill。
+免费生图，优先使用 SenseNova U1 Fast，其次使用 SiliconFlow Kolors。Key 永不写进本 skill。
 
 ## 生成图片
 
@@ -13,12 +13,14 @@ description: "免费生成图片。当用户要生成图片、插画、头像、
 python3 scripts/generate.py "<提示词>" <输出路径.png> [尺寸=1024x1024]
 ```
 
-- 免费、无水印，约 2 张/分钟的限速。
-- 若某个 model id 返回 "Model disabled"，用同一 key `GET https://api.siliconflow.cn/v1/models` 列出可用模型。
+- 如果配置了 `SENSENOVA_API_KEY`，自动使用 SenseNova U1 Fast（支持 11 档 2K 尺寸，脚本会自动把常见尺寸映射到最近比例）。
+- 如果没配 SenseNova、但有 `SILICONFLOW_API_KEY`，则使用 SiliconFlow Kolors。
+- 两个 key 都没配时会提示缺少 Key。
 
 ## Key
 
-- `SILICONFLOW_API_KEY`（SiliconFlow，免费模型 `Kwai-Kolors/Kolors`）。**获取**：注册/登录 [siliconflow.cn](https://siliconflow.cn) → 「API 密钥」→ 新建并复制（Kolors 免费）。
+- `SENSENOVA_API_KEY`（商汤日日新，优先）。**获取**：注册/登录 [platform.sensenova.cn](https://platform.sensenova.cn) → 管理中心 → API-Key 管理 → 创建 API-Key。
+- `SILICONFLOW_API_KEY`（SiliconFlow，备用）。**获取**：注册/登录 [siliconflow.cn](https://siliconflow.cn) → 「API 密钥」→ 新建并复制（Kolors 免费）。
 - 优先读环境变量；否则依次读 `~/.dsh/secrets/media-tools.env`、`~/.codex/secrets/media-tools.env`（每行 `KEY=value`，权限 600）。
 - 永远不要把 key 提交到仓库、写进 skill 或粘贴到公开文件。
 

--- a/skills/media-tools/scripts/generate.py
+++ b/skills/media-tools/scripts/generate.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 SILICONFLOW_URL = "https://api.siliconflow.com/v1/images/generations"
 SILICONFLOW_MODEL = "Kwai-Kolors/Kolors"
-SENSENOVA_URL = "https://token.sensenova.cn/v1/images/generations"
+SENSENOVA_URL = "https://token.sensenova.ai/v1/images/generations"
 SENSENOVA_MODEL = "sensenova-u1-fast"
 
 # SenseNova U1 Fast supported sizes (WxH -> aspect ratio).

--- a/skills/media-tools/scripts/generate.py
+++ b/skills/media-tools/scripts/generate.py
@@ -1,27 +1,88 @@
 #!/usr/bin/env python3
-"""Free image generation via SiliconFlow Kolors."""
+"""Generate images via SenseNova U1 Fast or SiliconFlow Kolors.
+
+Provider selection:
+1. If SENSENOVA_API_KEY is set, use SenseNova U1 Fast (https://token.sensenova.cn).
+2. Otherwise, if SILICONFLOW_API_KEY is set, use SiliconFlow Kolors.
+"""
 import json, os, sys, urllib.request
 from pathlib import Path
 
-def load_key(name):
+SILICONFLOW_URL = "https://api.siliconflow.com/v1/images/generations"
+SILICONFLOW_MODEL = "Kwai-Kolors/Kolors"
+SENSENOVA_URL = "https://token.sensenova.cn/v1/images/generations"
+SENSENOVA_MODEL = "sensenova-u1-fast"
+
+# SenseNova U1 Fast supported sizes (WxH -> aspect ratio).
+SENSENOVA_SIZES = {
+    "1344x3136": (9, 21),
+    "1536x2752": (9, 16),
+    "1664x2496": (2, 3),
+    "1760x2368": (3, 4),
+    "1824x2272": (4, 5),
+    "2048x2048": (1, 1),
+    "2272x1824": (5, 4),
+    "2368x1760": (4, 3),
+    "2496x1664": (3, 2),
+    "2752x1536": (16, 9),
+    "3072x1376": (21, 9),
+}
+
+def get_key(name):
     v = os.environ.get(name)
     if v:
-        return v
+        return v.strip()
     for env in (Path.home() / ".dsh/secrets/media-tools.env",
                 Path.home() / ".codex/secrets/media-tools.env"):
         if env.exists():
             for line in env.read_text().splitlines():
                 if line.startswith(name + "="):
                     return line.split("=", 1)[1].strip()
-    sys.exit(f"缺少 {name}：请设置环境变量，或在 ~/.dsh/secrets/media-tools.env 中配置（每行 KEY=value）")
+    return None
 
-def main():
-    if len(sys.argv) < 3:
-        sys.exit("用法: generate.py <prompt> <out.png> [size=1024x1024]")
-    prompt, out = sys.argv[1], sys.argv[2]
-    size = sys.argv[3] if len(sys.argv) > 3 else "1024x1024"
-    body = {"model": "Kwai-Kolors/Kolors", "prompt": prompt, "image_size": size, "batch_size": 1}
-    req = urllib.request.Request("https://api.siliconflow.cn/v1/images/generations",
+def load_key(name):
+    key = get_key(name)
+    if not key:
+        sys.exit(f"缺少 {name}：请设置环境变量，或在 ~/.dsh/secrets/media-tools.env 中配置（每行 KEY=value）")
+    return key
+
+def sensenova_size(size):
+    """Map a user-supplied size to one of SenseNova's supported sizes."""
+    size = (size or "2048x2048").strip().lower()
+    if size in SENSENOVA_SIZES:
+        return size
+    # ratio shorthand like 1:1 or 16:9
+    if ":" in size:
+        try:
+            wr, hr = map(int, size.split(":"))
+            for cand, (cw, ch) in SENSENOVA_SIZES.items():
+                if cw == wr and ch == hr:
+                    return cand
+        except ValueError:
+            pass
+    # WxH: pick nearest by aspect ratio
+    try:
+        w, h = map(int, size.split("x"))
+        target = w / h
+        best = min(SENSENOVA_SIZES.items(), key=lambda kv: abs((kv[1][0] / kv[1][1]) - target))
+        return best[0]
+    except (ValueError, ZeroDivisionError):
+        return "2048x2048"
+
+def generate_sensenova(prompt, out, size):
+    body = {"model": SENSENOVA_MODEL, "prompt": prompt, "size": sensenova_size(size), "n": 1}
+    req = urllib.request.Request(SENSENOVA_URL,
+        data=json.dumps(body).encode(),
+        headers={"Content-Type": "application/json", "Authorization": "Bearer " + load_key("SENSENOVA_API_KEY")}, method="POST")
+    with urllib.request.urlopen(req, timeout=300) as r:
+        data = json.load(r)
+    url = data["data"][0]["url"]
+    urllib.request.urlretrieve(url, out)
+    print("done:", out)
+
+def generate_siliconflow(prompt, out, size):
+    body = {"model": SILICONFLOW_MODEL, "prompt": prompt, "image_size": size, "batch_size": 1}
+    req = urllib.request.Request(SILICONFLOW_URL,
         data=json.dumps(body).encode(),
         headers={"Content-Type": "application/json", "Authorization": "Bearer " + load_key("SILICONFLOW_API_KEY")}, method="POST")
     with urllib.request.urlopen(req, timeout=300) as r:
@@ -29,6 +90,18 @@ def main():
     url = data["images"][0]["url"]
     urllib.request.urlretrieve(url, out)
     print("done:", out)
+
+def main():
+    if len(sys.argv) < 3:
+        sys.exit("用法: generate.py <prompt> <out.png> [size=1024x1024]")
+    prompt, out = sys.argv[1], sys.argv[2]
+    size = sys.argv[3] if len(sys.argv) > 3 else "1024x1024"
+    if get_key("SENSENOVA_API_KEY"):
+        generate_sensenova(prompt, out, size)
+    elif get_key("SILICONFLOW_API_KEY"):
+        generate_siliconflow(prompt, out, size)
+    else:
+        sys.exit("缺少图片生成 Key：请配置 SENSENOVA_API_KEY 或 SILICONFLOW_API_KEY（环境变量或 ~/.dsh/secrets/media-tools.env）")
 
 if __name__ == "__main__":
     main()

--- a/skills/vision-review/SKILL.md
+++ b/skills/vision-review/SKILL.md
@@ -5,7 +5,7 @@ description: "免费读图与视觉检查。当用户要分析、识别、检查
 
 # Vision Review（读图 / 视觉检查）
 
-免费读图，主引擎智谱 GLM-4V-Flash，可选 SiliconFlow Qwen3-VL、Google Gemini 备用。Key 永不写进本 skill。
+免费读图，主引擎智谱 GLM-4V-Flash，可选 SiliconFlow Qwen3-VL、SenseNova（商汤日日新）、Google Gemini 备用。Key 永不写进本 skill。
 
 ## 用法
 
@@ -25,6 +25,7 @@ python3 scripts/vision.py <图片路径...> [--prompt="..."] [--provider=NAME] [
 
 - `GLM_API_KEY`（智谱，免费视觉模型 `glm-4v-flash`）。**获取**：注册/登录 [open.bigmodel.cn](https://open.bigmodel.cn) → 「API Keys」→ 新建并复制（`glm-4v-flash` 免费，无需付费）。
 - `SILICONFLOW_API_KEY`（硅基流动，免费额度，可选）。**和 `media-tools` 生图同一个 key**，无需新申请；配好后自动加入回退链。
+- `SENSENOVA_API_KEY`（商汤日日新，可选）。配好后自动加入回退链；默认模型 `sensenova-6.7-flash-lite`，可用 `SENSENOVA_VISION_MODEL` 覆盖。
 - `GEMINI_API_KEY`（Google，免费，可选）。**获取**：[aistudio.google.com](https://aistudio.google.com) → 「Get API key」（约三分钟，无需信用卡）；配好后自动加入回退链。注意：Google 域名在本机网络可能不可直连，需要代理才可用——在同一个 secrets 文件里写 `GEMINI_PROXY=http://127.0.0.1:7897`（换成你的代理地址）即可，只有 Gemini 引擎走代理，智谱等国内引擎保持直连。
 - 优先读环境变量；否则依次读 `~/.dsh/secrets/media-tools.env`、`~/.codex/secrets/media-tools.env`（每行 `KEY=value`，权限 600）。
 - 永远不要把 key 提交到仓库、写进 skill 或粘贴到公开文件。

--- a/skills/vision-review/SKILL.md
+++ b/skills/vision-review/SKILL.md
@@ -25,7 +25,7 @@ python3 scripts/vision.py <图片路径...> [--prompt="..."] [--provider=NAME] [
 
 - `GLM_API_KEY`（智谱，免费视觉模型 `glm-4v-flash`）。**获取**：注册/登录 [open.bigmodel.cn](https://open.bigmodel.cn) → 「API Keys」→ 新建并复制（`glm-4v-flash` 免费，无需付费）。
 - `SILICONFLOW_API_KEY`（硅基流动，免费额度，可选）。**和 `media-tools` 生图同一个 key**，无需新申请；配好后自动加入回退链。
-- `SENSENOVA_API_KEY`（商汤日日新，可选）。配好后自动加入回退链；默认模型 `sensenova-6.7-flash-lite`，可用 `SENSENOVA_VISION_MODEL` 覆盖。
+- `SENSENOVA_API_KEY`（商汤日日新，可选）。配好后自动加入回退链；默认模型 `sensenova-6.8-flash-lite`，可用 `SENSENOVA_VISION_MODEL` 覆盖。
 - `GEMINI_API_KEY`（Google，免费，可选）。**获取**：[aistudio.google.com](https://aistudio.google.com) → 「Get API key」（约三分钟，无需信用卡）；配好后自动加入回退链。注意：Google 域名在本机网络可能不可直连，需要代理才可用——在同一个 secrets 文件里写 `GEMINI_PROXY=http://127.0.0.1:7897`（换成你的代理地址）即可，只有 Gemini 引擎走代理，智谱等国内引擎保持直连。
 - 优先读环境变量；否则依次读 `~/.dsh/secrets/media-tools.env`、`~/.codex/secrets/media-tools.env`（每行 `KEY=value`，权限 600）。
 - 永远不要把 key 提交到仓库、写进 skill 或粘贴到公开文件。

--- a/skills/vision-review/scripts/vision.py
+++ b/skills/vision-review/scripts/vision.py
@@ -3,9 +3,11 @@
 
 Engines (tried in order):
 1. Zhipu GLM-4V-Flash (free) — primary.
-2. Google Gemini (free key) — auto-joins the chain when GEMINI_API_KEY is set;
+2. SiliconFlow Qwen3-VL — auto-joins when SILICONFLOW_API_KEY is set.
+3. SenseNova (商汤日日新) — auto-joins when SENSENOVA_API_KEY is set.
+4. Google Gemini (free key) — auto-joins when GEMINI_API_KEY is set;
    the OpenAI-compatible Gemini endpoint carries the same code path.
-3. VISION_FALLBACKS — any extra OpenAI-compatible multimodal endpoints (JSON).
+5. VISION_FALLBACKS — any extra OpenAI-compatible multimodal endpoints (JSON).
 
 `--structured` mirrors the ModLens evidence contract: a JSON object with
 summary / ocr.full_text / layout regions in reading order / semantics
@@ -40,7 +42,7 @@ PRIMARY = {
 def siliconflow_engine():
     return {
         "name": "siliconflow-qwen",
-        "baseUrl": "https://api.siliconflow.cn/v1",
+        "baseUrl": "https://api.siliconflow.com/v1",
         "apiKeyEnv": "SILICONFLOW_API_KEY",
         "model": os.environ.get("SILICONFLOW_VISION_MODEL", "Qwen/Qwen3-VL-8B-Instruct"),
         "maxTokens": 1024,
@@ -60,6 +62,17 @@ def gemini_engine():
         "maxTokens": 1024,
         "jsonObject": True,
         "proxy": proxy or None,
+    }
+
+# 备用引擎：商汤 SenseNova（Token Plan，OpenAI 兼容；sensenova-6.7-flash-lite 支持图文输入）。
+def sensenova_engine():
+    return {
+        "name": "sensenova",
+        "baseUrl": "https://token.sensenova.cn/v1",
+        "apiKeyEnv": "SENSENOVA_API_KEY",
+        "model": os.environ.get("SENSENOVA_VISION_MODEL", "sensenova-6.7-flash-lite"),
+        "maxTokens": 1024,
+        "jsonObject": False,
     }
 
 def load_key(name):
@@ -100,6 +113,8 @@ def engines():
     chain = [PRIMARY]
     if load_key("SILICONFLOW_API_KEY"):
         chain.append(siliconflow_engine())
+    if load_key("SENSENOVA_API_KEY"):
+        chain.append(sensenova_engine())
     if load_key("GEMINI_API_KEY"):
         chain.append(gemini_engine())
     chain.extend(load_fallbacks())
@@ -107,7 +122,7 @@ def engines():
 
 def available_engines():
     """Every candidate engine, configured or not (for listing, pinning, doctor)."""
-    chain = [PRIMARY, siliconflow_engine(), gemini_engine()]
+    chain = [PRIMARY, siliconflow_engine(), sensenova_engine(), gemini_engine()]
     chain.extend(load_fallbacks())
     return chain
 
@@ -220,9 +235,9 @@ def doctor():
     all_ok = True
     for eng in available_engines():
         name = eng["name"]
-        if not load_key(eng["apiKeyEnv"]) and name == "gemini":
+        if not load_key(eng["apiKeyEnv"]) and name in ("gemini", "sensenova"):
             print(f"  [--] {name}: {eng['model']} @ {eng['baseUrl']} → 缺少 {eng['apiKeyEnv']}"
-                  f"（免费领取：https://aistudio.google.com，配好后自动加入回退链）")
+                  f"（配置后自动加入回退链）")
             continue
         try:
             status = ping_engine(eng)

--- a/skills/vision-review/scripts/vision.py
+++ b/skills/vision-review/scripts/vision.py
@@ -64,13 +64,13 @@ def gemini_engine():
         "proxy": proxy or None,
     }
 
-# 备用引擎：商汤 SenseNova（Token Plan，OpenAI 兼容；sensenova-6.7-flash-lite 支持图文输入）。
+# 备用引擎：商汤 SenseNova（Token Plan，OpenAI 兼容；sensenova-6.8-flash-lite 支持图文输入）。
 def sensenova_engine():
     return {
         "name": "sensenova",
-        "baseUrl": "https://token.sensenova.cn/v1",
+        "baseUrl": "https://token.sensenova.ai/v1",
         "apiKeyEnv": "SENSENOVA_API_KEY",
-        "model": os.environ.get("SENSENOVA_VISION_MODEL", "sensenova-6.7-flash-lite"),
+        "model": os.environ.get("SENSENOVA_VISION_MODEL", "sensenova-6.8-flash-lite"),
         "maxTokens": 1024,
         "jsonObject": False,
     }


### PR DESCRIPTION
## Summary

Adds support for the SenseNova (商汤日日新) platform to `dsh-media-skills`:

- **vision-review**: new `sensenova` engine in the failover chain (`GLM → SiliconFlow → SenseNova → Gemini`), using the OpenAI-compatible endpoint at `https://token.sensenova.ai/v1` and model `sensenova-6.8-flash-lite`.
- **media-tools**: SenseNova U1 Fast image generation via `https://token.sensenova.ai/v1/images/generations`, used automatically when `SENSENOVA_API_KEY` is set; falls back to SiliconFlow otherwise.
- **index.js**: seeds a `sensenova-vision` provider route in DSH so the model selector gains 「商汤 SenseNova（视觉）」.
- **docs**: updated both SKILL.md files with SenseNova setup instructions.

## Key

Uses `SENSENOVA_API_KEY` from environment or `~/.dsh/secrets/media-tools.env`.

## Verification

- Python / Node syntax checks pass.
- `vision.py --doctor` lists the SenseNova engine and reports `ok`.
- SenseNova successfully read a sample screenshot/image with `sensenova-6.8-flash-lite`.
- Image generation endpoint is wired to `sensenova-u1-fast`; note the engine may be temporarily unavailable on the international endpoint.